### PR TITLE
Dynamic imports - for model-specific packages

### DIFF
--- a/chebifier/prediction_models/__init__.py
+++ b/chebifier/prediction_models/__init__.py
@@ -1,8 +1,9 @@
 from .base_predictor import BasePredictor
-from .chemlog_predictor import ChemlogPeptidesPredictor, ChemlogExtraPredictor
+from .c3p_predictor import C3PPredictor
+from .chebi_lookup import ChEBILookupPredictor
+from .chemlog_predictor import ChemlogExtraPredictor, ChemlogPeptidesPredictor
 from .electra_predictor import ElectraPredictor
 from .gnn_predictor import ResGatedPredictor
-from .chebi_lookup import ChEBILookupPredictor
 
 __all__ = [
     "BasePredictor",
@@ -11,4 +12,5 @@ __all__ = [
     "ResGatedPredictor",
     "ChEBILookupPredictor",
     "ChemlogExtraPredictor",
+    "C3PPredictor",
 ]

--- a/chebifier/prediction_models/c3p_predictor.py
+++ b/chebifier/prediction_models/c3p_predictor.py
@@ -26,7 +26,7 @@ class C3PPredictor(BasePredictor):
         
     @modelwise_smiles_lru_cache.batch_decorator
     def predict_smiles_list(self, smiles_list: list[str]) -> list:
-      from c3p import classifier as c3p_classifier
+        from c3p import classifier as c3p_classifier
         result_list = c3p_classifier.classify(
             list(smiles_list),
             self.program_directory,

--- a/chebifier/prediction_models/c3p_predictor.py
+++ b/chebifier/prediction_models/c3p_predictor.py
@@ -1,8 +1,6 @@
 from functools import lru_cache
-from typing import Optional, List
 from pathlib import Path
-
-from c3p import classifier as c3p_classifier
+from typing import List, Optional
 
 from chebifier.prediction_models import BasePredictor
 
@@ -26,6 +24,8 @@ class C3PPredictor(BasePredictor):
 
     @lru_cache(maxsize=100)
     def predict_smiles_tuple(self, smiles_list: tuple[str]) -> list:
+        from c3p import classifier as c3p_classifier
+
         result_list = c3p_classifier.classify(
             list(smiles_list),
             self.program_directory,
@@ -50,6 +50,8 @@ class C3PPredictor(BasePredictor):
         C3P provides natural language explanations for each prediction (positive or negative). Since there are more
         than 300 classes, only take the positive ones.
         """
+        from c3p import classifier as c3p_classifier
+
         highlights = []
         result_list = c3p_classifier.classify(
             [smiles], self.program_directory, self.chemical_classes, strict=False

--- a/chebifier/prediction_models/c3p_predictor.py
+++ b/chebifier/prediction_models/c3p_predictor.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 from typing import List, Optional
 
-from c3p import classifier as c3p_classifier
-
 from chebifier import modelwise_smiles_lru_cache
 from chebifier.prediction_models import BasePredictor
 

--- a/chebifier/prediction_models/c3p_predictor.py
+++ b/chebifier/prediction_models/c3p_predictor.py
@@ -23,10 +23,11 @@ class C3PPredictor(BasePredictor):
         self.program_directory = program_directory
         self.chemical_classes = chemical_classes
         self.chebi_graph = kwargs.get("chebi_graph", None)
-        
+
     @modelwise_smiles_lru_cache.batch_decorator
     def predict_smiles_list(self, smiles_list: list[str]) -> list:
         from c3p import classifier as c3p_classifier
+
         result_list = c3p_classifier.classify(
             list(smiles_list),
             self.program_directory,

--- a/chebifier/prediction_models/chebi_lookup.py
+++ b/chebifier/prediction_models/chebi_lookup.py
@@ -8,7 +8,6 @@ from chebifier import modelwise_smiles_lru_cache
 from chebifier.prediction_models import BasePredictor
 from chebifier.utils import load_chebi_graph
 
-from chebifier.prediction_models import BasePredictor
 
 
 class ChEBILookupPredictor(BasePredictor):
@@ -19,7 +18,6 @@ class ChEBILookupPredictor(BasePredictor):
         chebi_version: int = 241,
         **kwargs,
     ):
-        from chebifier.utils import load_chebi_graph
 
         super().__init__(model_name, **kwargs)
         self._description = (

--- a/chebifier/prediction_models/chebi_lookup.py
+++ b/chebifier/prediction_models/chebi_lookup.py
@@ -9,7 +9,6 @@ from chebifier.prediction_models import BasePredictor
 from chebifier.utils import load_chebi_graph
 
 
-
 class ChEBILookupPredictor(BasePredictor):
     def __init__(
         self,

--- a/chebifier/prediction_models/chebi_lookup.py
+++ b/chebifier/prediction_models/chebi_lookup.py
@@ -1,15 +1,14 @@
+import json
+import os
 from functools import lru_cache
 from typing import Optional
 
-from chebifier.prediction_models import BasePredictor
-import os
-import networkx as nx
 from rdkit import Chem
-import json
+
+from chebifier.prediction_models import BasePredictor
 
 
 class ChEBILookupPredictor(BasePredictor):
-
     def __init__(
         self,
         model_name: str,
@@ -49,6 +48,8 @@ class ChEBILookupPredictor(BasePredictor):
         return smiles_lookup
 
     def build_smiles_lookup(self):
+        import networkx as nx
+
         smiles_lookup = dict()
         for chebi_id, smiles in nx.get_node_attributes(
             self.chebi_graph, "smiles"
@@ -152,7 +153,8 @@ if __name__ == "__main__":
     # Example usage
     smiles_list = [
         "CCO",
-        "C1=CC=CC=C1" "*C(=O)OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(*)=O",
+        "C1=CC=CC=C1",
+        "*C(=O)OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(*)=O",
     ]  # SMILES with 251 matches in ChEBI
     predictions = predictor.predict_smiles_list(smiles_list)
     print(predictions)

--- a/chebifier/prediction_models/chemlog_predictor.py
+++ b/chebifier/prediction_models/chemlog_predictor.py
@@ -1,21 +1,7 @@
+from functools import lru_cache
 from typing import Optional
 
 import tqdm
-from chemlog.alg_classification.charge_classifier import get_charge_category
-from chemlog.alg_classification.peptide_size_classifier import get_n_amino_acid_residues
-from chemlog.alg_classification.proteinogenics_classifier import (
-    get_proteinogenic_amino_acids,
-)
-from chemlog.alg_classification.substructure_classifier import (
-    is_diketopiperazine,
-    is_emericellamide,
-)
-from chemlog.cli import CLASSIFIERS, _smiles_to_mol, strategy_call
-from chemlog_extra.alg_classification.by_element_classification import (
-    XMolecularEntityClassifier,
-    OrganoXCompoundClassifier,
-)
-from functools import lru_cache
 
 from .base_predictor import BasePredictor
 
@@ -47,15 +33,14 @@ AA_DICT = {
 
 
 class ChemlogExtraPredictor(BasePredictor):
-
-    CHEMLOG_CLASSIFIER = None
-
     def __init__(self, model_name: str, **kwargs):
         super().__init__(model_name, **kwargs)
         self.chebi_graph = kwargs.get("chebi_graph", None)
-        self.classifier = self.CHEMLOG_CLASSIFIER()
+        self.classifier = None
 
     def predict_smiles_tuple(self, smiles_list: tuple[str]) -> list:
+        from chemlog.cli import _smiles_to_mol
+
         mol_list = [_smiles_to_mol(smiles) for smiles in smiles_list]
         res = self.classifier.classify(mol_list)
         if self.chebi_graph is not None:
@@ -72,17 +57,29 @@ class ChemlogExtraPredictor(BasePredictor):
 
 
 class ChemlogXMolecularEntityPredictor(ChemlogExtraPredictor):
+    def __init__(self, model_name: str, **kwargs):
+        from chemlog_extra.alg_classification.by_element_classification import (
+            XMolecularEntityClassifier,
+        )
 
-    CHEMLOG_CLASSIFIER = XMolecularEntityClassifier
+        super().__init__(model_name, **kwargs)
+        self.classifier = XMolecularEntityClassifier()
 
 
 class ChemlogOrganoXCompoundPredictor(ChemlogExtraPredictor):
+    def __init__(self, model_name: str, **kwargs):
+        from chemlog_extra.alg_classification.by_element_classification import (
+            OrganoXCompoundClassifier,
+        )
 
-    CHEMLOG_CLASSIFIER = OrganoXCompoundClassifier
+        super().__init__(model_name, **kwargs)
+        self.classifier = OrganoXCompoundClassifier()
 
 
 class ChemlogPeptidesPredictor(BasePredictor):
     def __init__(self, model_name: str, **kwargs):
+        from chemlog.cli import CLASSIFIERS
+
         super().__init__(model_name, **kwargs)
         self.strategy = "algo"
         self.chebi_graph = kwargs.get("chebi_graph", None)
@@ -99,6 +96,8 @@ class ChemlogPeptidesPredictor(BasePredictor):
 
     @lru_cache(maxsize=100)
     def predict_smiles(self, smiles: str) -> Optional[dict]:
+        from chemlog.cli import _smiles_to_mol, strategy_call
+
         mol = _smiles_to_mol(smiles)
         if mol is None:
             return None
@@ -134,6 +133,19 @@ class ChemlogPeptidesPredictor(BasePredictor):
 
     def get_chemlog_result_info(self, smiles):
         """Get classification for single molecule with additional information."""
+        from chemlog.alg_classification.charge_classifier import get_charge_category
+        from chemlog.alg_classification.peptide_size_classifier import (
+            get_n_amino_acid_residues,
+        )
+        from chemlog.alg_classification.proteinogenics_classifier import (
+            get_proteinogenic_amino_acids,
+        )
+        from chemlog.alg_classification.substructure_classifier import (
+            is_diketopiperazine,
+            is_emericellamide,
+        )
+        from chemlog.cli import _smiles_to_mol
+
         mol = _smiles_to_mol(smiles)
         if mol is None or not smiles:
             return {"error": "Failed to parse SMILES"}

--- a/chebifier/prediction_models/chemlog_predictor.py
+++ b/chebifier/prediction_models/chemlog_predictor.py
@@ -1,9 +1,9 @@
-from functools import lru_cache
 from typing import Optional
 
 import tqdm
 
 from .base_predictor import BasePredictor
+from .. import modelwise_smiles_lru_cache
 
 AA_DICT = {
     "A": "L-alanine",
@@ -33,7 +33,7 @@ AA_DICT = {
 
 
 class ChemlogExtraPredictor(BasePredictor):
-  
+
     def __init__(self, model_name: str, **kwargs):
         super().__init__(model_name, **kwargs)
         self.chebi_graph = kwargs.get("chebi_graph", None)
@@ -42,6 +42,7 @@ class ChemlogExtraPredictor(BasePredictor):
     @modelwise_smiles_lru_cache.batch_decorator
     def predict_smiles_list(self, smiles_list: list[str]) -> list:
         from chemlog.cli import _smiles_to_mol
+
         mol_list = [_smiles_to_mol(smiles) for smiles in smiles_list]
         res = self.classifier.classify(mol_list)
         if self.chebi_graph is not None:

--- a/chebifier/prediction_models/electra_predictor.py
+++ b/chebifier/prediction_models/electra_predictor.py
@@ -1,6 +1,11 @@
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from .nn_predictor import NNPredictor
+
+if TYPE_CHECKING:
+    from chebai.models.electra import Electra
 
 
 def build_graph_from_attention(att, node_labels, token_labels, threshold=0.0):
@@ -40,7 +45,7 @@ class ElectraPredictor(NNPredictor):
         super().__init__(model_name, ckpt_path, reader_cls=ChemDataReader, **kwargs)
         print(f"Initialised Electra model {self.model_name} (device: {self.device})")
 
-    def init_model(self, ckpt_path: str, **kwargs) -> "Electra":  # noqa: F821
+    def init_model(self, ckpt_path: str, **kwargs) -> Electra:
         from chebai.models.electra import Electra
 
         model = Electra.load_from_checkpoint(

--- a/chebifier/prediction_models/electra_predictor.py
+++ b/chebifier/prediction_models/electra_predictor.py
@@ -45,7 +45,7 @@ class ElectraPredictor(NNPredictor):
         super().__init__(model_name, ckpt_path, reader_cls=ChemDataReader, **kwargs)
         print(f"Initialised Electra model {self.model_name} (device: {self.device})")
 
-    def init_model(self, ckpt_path: str, **kwargs) -> Electra:
+    def init_model(self, ckpt_path: str, **kwargs) -> "Electra":
         from chebai.models.electra import Electra
 
         model = Electra.load_from_checkpoint(

--- a/chebifier/prediction_models/electra_predictor.py
+++ b/chebifier/prediction_models/electra_predictor.py
@@ -1,6 +1,4 @@
 import numpy as np
-from chebai.models.electra import Electra
-from chebai.preprocessing.reader import EMBEDDING_OFFSET, ChemDataReader
 
 from .nn_predictor import NNPredictor
 
@@ -37,10 +35,14 @@ def build_graph_from_attention(att, node_labels, token_labels, threshold=0.0):
 
 class ElectraPredictor(NNPredictor):
     def __init__(self, model_name: str, ckpt_path: str, **kwargs):
+        from chebai.preprocessing.reader import ChemDataReader
+
         super().__init__(model_name, ckpt_path, reader_cls=ChemDataReader, **kwargs)
         print(f"Initialised Electra model {self.model_name} (device: {self.device})")
 
-    def init_model(self, ckpt_path: str, **kwargs) -> Electra:
+    def init_model(self, ckpt_path: str, **kwargs) -> "Electra":  # noqa: F821
+        from chebai.models.electra import Electra
+
         model = Electra.load_from_checkpoint(
             ckpt_path,
             map_location=self.device,
@@ -53,6 +55,8 @@ class ElectraPredictor(NNPredictor):
         return model
 
     def explain_smiles(self, smiles) -> dict:
+        from chebai.preprocessing.reader import EMBEDDING_OFFSET
+
         reader = self.reader_cls()
         token_dict = reader.to_data(dict(features=smiles, labels=None))
         tokens = np.array(token_dict["features"]).astype(int).tolist()

--- a/chebifier/prediction_models/gnn_predictor.py
+++ b/chebifier/prediction_models/gnn_predictor.py
@@ -33,7 +33,7 @@ class ResGatedPredictor(NNPredictor):
         module = __import__(module_path, fromlist=[class_name])
         return getattr(module, class_name)
 
-    def init_model(self, ckpt_path: str, **kwargs) -> ResGatedGraphConvNetGraphPred:
+    def init_model(self, ckpt_path: str, **kwargs) -> "ResGatedGraphConvNetGraphPred":
         import torch
         from chebai_graph.models.graph import ResGatedGraphConvNetGraphPred
 

--- a/chebifier/prediction_models/gnn_predictor.py
+++ b/chebifier/prediction_models/gnn_predictor.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING
+
 from .nn_predictor import NNPredictor
+
+if TYPE_CHECKING:
+    from chebai_graph.models.graph import ResGatedGraphConvNetGraphPred
 
 
 class ResGatedPredictor(NNPredictor):
@@ -28,9 +33,7 @@ class ResGatedPredictor(NNPredictor):
         module = __import__(module_path, fromlist=[class_name])
         return getattr(module, class_name)
 
-    def init_model(
-        self, ckpt_path: str, **kwargs
-    ) -> "ResGatedGraphConvNetGraphPred":  # noqa: F821
+    def init_model(self, ckpt_path: str, **kwargs) -> ResGatedGraphConvNetGraphPred:
         import torch
         from chebai_graph.models.graph import ResGatedGraphConvNetGraphPred
 

--- a/chebifier/prediction_models/gnn_predictor.py
+++ b/chebifier/prediction_models/gnn_predictor.py
@@ -1,15 +1,11 @@
-import chebai_graph.preprocessing.properties as p
-import torch
-from chebai_graph.models.graph import ResGatedGraphConvNetGraphPred
-from chebai_graph.preprocessing.property_encoder import IndexEncoder, OneHotEncoder
-from chebai_graph.preprocessing.reader import GraphPropertyReader
-from torch_geometric.data.data import Data as GeomData
-
 from .nn_predictor import NNPredictor
 
 
 class ResGatedPredictor(NNPredictor):
     def __init__(self, model_name: str, ckpt_path: str, molecular_properties, **kwargs):
+        from chebai_graph.preprocessing.properties import MolecularProperty
+        from chebai_graph.preprocessing.reader import GraphPropertyReader
+
         super().__init__(
             model_name, ckpt_path, reader_cls=GraphPropertyReader, **kwargs
         )
@@ -23,7 +19,7 @@ class ResGatedPredictor(NNPredictor):
             properties = []
         self.molecular_properties = properties
         assert isinstance(self.molecular_properties, list) and all(
-            isinstance(prop, p.MolecularProperty) for prop in self.molecular_properties
+            isinstance(prop, MolecularProperty) for prop in self.molecular_properties
         )
         print(f"Initialised GNN model {self.model_name} (device: {self.device})")
 
@@ -32,7 +28,12 @@ class ResGatedPredictor(NNPredictor):
         module = __import__(module_path, fromlist=[class_name])
         return getattr(module, class_name)
 
-    def init_model(self, ckpt_path: str, **kwargs) -> ResGatedGraphConvNetGraphPred:
+    def init_model(
+        self, ckpt_path: str, **kwargs
+    ) -> "ResGatedGraphConvNetGraphPred":  # noqa: F821
+        import torch
+        from chebai_graph.models.graph import ResGatedGraphConvNetGraphPred
+
         model = ResGatedGraphConvNetGraphPred.load_from_checkpoint(
             ckpt_path,
             map_location=torch.device(self.device),
@@ -45,6 +46,14 @@ class ResGatedPredictor(NNPredictor):
         return model
 
     def read_smiles(self, smiles):
+        import torch
+        from chebai_graph.preprocessing.properties import AtomProperty, BondProperty
+        from chebai_graph.preprocessing.property_encoder import (
+            IndexEncoder,
+            OneHotEncoder,
+        )
+        from torch_geometric.data.data import Data as GeomData
+
         reader = self.reader_cls()
         d = reader.to_data(dict(features=smiles, labels=None))
         geom_data = d["features"]
@@ -87,9 +96,9 @@ class ResGatedPredictor(NNPredictor):
                     encoded_values = encoded_values.unsqueeze(1)
             else:
                 encoded_values = torch.zeros((0, prop.encoder.get_encoding_length()))
-            if isinstance(prop, p.AtomProperty):
+            if isinstance(prop, AtomProperty):
                 x = torch.cat([x, encoded_values], dim=1)
-            elif isinstance(prop, p.BondProperty):
+            elif isinstance(prop, BondProperty):
                 edge_attr = torch.cat([edge_attr, encoded_values], dim=1)
             else:
                 molecule_attr = torch.cat([molecule_attr, encoded_values[0]], dim=1)

--- a/chebifier/prediction_models/nn_predictor.py
+++ b/chebifier/prediction_models/nn_predictor.py
@@ -1,7 +1,6 @@
 from functools import lru_cache
 
 import numpy as np
-import torch
 import tqdm
 from rdkit import Chem
 
@@ -17,6 +16,8 @@ class NNPredictor(BasePredictor):
         target_labels_path: str,
         **kwargs,
     ):
+        import torch
+
         super().__init__(model_name, **kwargs)
         self.reader_cls = reader_cls
 
@@ -56,6 +57,8 @@ class NNPredictor(BasePredictor):
     def predict_smiles_tuple(self, smiles_list: tuple[str]) -> list:
         """Returns a list with the length of smiles_list, each element is either None (=failure) or a dictionary
         Of classes and predicted values."""
+        import torch
+
         token_dicts = []
         could_not_parse = []
         index_map = dict()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,15 @@ classifiers = [
 dependencies = [
     "click",
     "pyyaml",
-    "torch",
     "tqdm",
     "rdkit",
-    "chebai>=1.0.1",
-    "chemlog>=1.0.4",
+    # Package to install manually if required
+    #"chebai>=1.0.1",
+    #"chemlog>=1.0.4",
+
     # pypi does not support git dependencies
     #"chemlog_extra @ git+https://github.com/ChEB-AI/chemlog-extra.git",
-    "c3p"
+
     # forked version of c3p is windows-compatible
     #"c3p @ git+https://github.com/sfluegel05/c3p.git"
 ]


### PR DESCRIPTION
- #11 

**Note On Dynamic Imports**: 
Even if you write import package inside a method that’s called 100 times, Python’s import system **caches** it.
Because of Python’s internal import caching mechanism.
The first time, Python loads torch from disk and stores it in sys.modules.
Every subsequent import torch, even if it appears in a loop or method, simply reuses the already-loaded module.
So performance-wise, **it’s almost free after the first import.**


Check documentation here: https://docs.python.org/3/reference/import.html#the-module-cache


https://docs.python.org/3/faq/programming.html#why-are-modules-imported-multiple-times
> Only move imports into a local scope, such as inside a function definition, if it’s necessary to solve a problem such as avoiding a circular import or are trying to reduce the initialization time of a module. This technique is especially helpful if many of the imports are unnecessary depending on how the program executes. You may also want to move imports into a function if the modules are only ever used in that function. Note that loading a module the first time may be expensive because of the one time initialization of the module, **but loading a module multiple times is virtually free**, costing only a couple of dictionary lookups. Even if the module name has gone out of scope, the module is probably available in [sys.modules](https://docs.python.org/3/library/sys.html#sys.modules).