### PR TITLE
Avoid gradient tracking

### DIFF
--- a/chebifier/prediction_models/nn_predictor.py
+++ b/chebifier/prediction_models/nn_predictor.py
@@ -22,6 +22,8 @@ class NNPredictor(BasePredictor):
 
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model = self.init_model(ckpt_path=ckpt_path)
+        self.model.eval()
+
         self.target_labels = [
             line.strip() for line in open(target_labels_path, encoding="utf-8")
         ]
@@ -32,6 +34,7 @@ class NNPredictor(BasePredictor):
             "Model initialization must be implemented in subclasses."
         )
 
+    @torch.inference_mode()
     def calculate_results(self, batch):
         collator = self.reader_cls.COLLATOR()
         dat = self.model._process_batch(collator(batch).to(self.device), 0)


### PR DESCRIPTION


For inference, PyTorch Lightning automatically calls `model.eval()` and wraps the forward pass in `torch.inference_mode()`.

When performing inference **outside Lightning**, using only `model.eval()` is **not sufficient**.

* `model.eval()` **does not disable gradients**. It only switches layers like dropout and batchnorm into evaluation mode.
* Gradients are still tracked by autograd unless explicitly disabled.

Disabling gradient tracking is important because it:

1. **Reduces memory usage** by avoiding storing intermediate activations for backpropagation.
2. **Speeds up inference** by skipping autograd bookkeeping.

For this purpose, `torch.inference_mode()` is recommended. It is newer, faster, and more restrictive than `torch.no_grad()`, making it ideal for inference.

**References:**

* [Behavior of `model.eval()` in PyTorch](https://discuss.pytorch.org/t/behavior-of-model-eval-does-it-disable-gradient-operations/121879)
* [Difference between `torch.no_grad()` and `torch.inference_mode()`](https://discuss.pytorch.org/t/pytorch-torch-no-grad-vs-torch-inference-mode/134099)

