### PR TITLE
Lopster integration + bug fixes

### DIFF
--- a/chebifier/ensemble/weighted_majority_ensemble.py
+++ b/chebifier/ensemble/weighted_majority_ensemble.py
@@ -33,13 +33,23 @@ class WMVwithPPVNPVEnsemble(BaseEnsemble):
             if model.classwise_weights is None:
                 continue
             for cls, weights in model.classwise_weights.items():
+                if cls not in predicted_classes:
+                    continue
+                ppv = (
+                    weights["TP"] / (weights["TP"] + weights["FP"])
+                    if (weights["TP"] + weights["FP"]) > 0
+                    else 1.0
+                )
+                npv = (
+                    weights["TN"] / (weights["TN"] + weights["FN"])
+                    if (weights["TN"] + weights["FN"]) > 0
+                    else 1.0
+                )
                 positive_weights[predicted_classes[cls], j] *= (
-                    weights["PPV"] * self.weighting_strength
-                    + (1 - self.weighting_strength)
+                    ppv * self.weighting_strength + (1 - self.weighting_strength)
                 ) ** self.weighting_exponent
                 negative_weights[predicted_classes[cls], j] *= (
-                    weights["NPV"] * self.weighting_strength
-                    + (1 - self.weighting_strength)
+                    npv * self.weighting_strength + (1 - self.weighting_strength)
                 ) ** self.weighting_exponent
 
         if self.verbose_output:

--- a/chebifier/model_registry.py
+++ b/chebifier/model_registry.py
@@ -12,6 +12,8 @@ from chebifier.prediction_models import (
 from chebifier.prediction_models.c3p_predictor import C3PPredictor
 from chebifier.prediction_models.chemlog_predictor import (
     ChemlogAllPredictor,
+    ChemLogLopsterClingoPredictor,
+    ChemlogLopsterPredictor,
     ChemlogOrganoXCompoundPredictor,
     ChemlogXMolecularEntityPredictor,
 )
@@ -33,6 +35,8 @@ MODEL_TYPES = {
     "chebi_lookup": ChEBILookupPredictor,
     "chemlog_element": ChemlogXMolecularEntityPredictor,
     "chemlog_organox": ChemlogOrganoXCompoundPredictor,
+    "lopster": ChemlogLopsterPredictor,
+    "lopster_clingo": ChemLogLopsterClingoPredictor,
     "c3p": C3PPredictor,
 }
 

--- a/chebifier/prediction_models/chemlog_predictor.py
+++ b/chebifier/prediction_models/chemlog_predictor.py
@@ -107,6 +107,22 @@ class ChemlogOrganoXCompoundPredictor(ChemlogExtraPredictor):
         self.classifier = OrganoXCompoundClassifier(chebi_graph=self.chebi_graph)
 
 
+class ChemlogLopsterPredictor(ChemlogExtraPredictor):
+    def __init__(self, model_name: str, **kwargs):
+        from chemlog.lopster.lopster_classifier import LopsterClassifier
+
+        super().__init__(model_name, **kwargs)
+        self.classifier = LopsterClassifier()
+
+
+class ChemLogLopsterClingoPredictor(ChemlogExtraPredictor):
+    def __init__(self, model_name: str, **kwargs):
+        from chemlog.lopster.lopster_classifier import LopsterClingoClassifier
+
+        super().__init__(model_name, **kwargs)
+        self.classifier = LopsterClingoClassifier()
+
+
 class ChemlogPeptidesPredictor(BasePredictor):
     def __init__(self, model_name: str, **kwargs):
         from chemlog.cli import CLASSIFIERS

--- a/chebifier/prediction_models/electra_predictor.py
+++ b/chebifier/prediction_models/electra_predictor.py
@@ -53,7 +53,6 @@ class ElectraPredictor(NNPredictor):
             map_location=self.device,
             criterion=None,
             strict=False,
-            metrics=dict(train=dict(), test=dict(), validation=dict()),
             pretrained_checkpoint=None,
         )
         model.eval()

--- a/chebifier/prediction_models/gnn_predictor.py
+++ b/chebifier/prediction_models/gnn_predictor.py
@@ -68,8 +68,6 @@ class ResGatedPredictor(NNPredictor):
             map_location=torch.device(self.device),
             criterion=None,
             strict=False,
-            metrics=dict(train=dict(), test=dict(), validation=dict()),
-            pretrained_checkpoint=None,
         )
         model.eval()
         return model
@@ -113,8 +111,6 @@ class GATPredictor(ResGatedPredictor):
             map_location=torch.device(self.device),
             criterion=None,
             strict=False,
-            metrics=dict(train=dict(), test=dict(), validation=dict()),
-            pretrained_checkpoint=None,
         )
         model.eval()
         return model


### PR DESCRIPTION
Adds a wrapper for the ChemLog Lopster classifier (in both algorithmic and Clingo ASP version)
Also:
- PPV/NPV are now calculated from the confusion matrix
- I removed some parameters that got added to checkpoints automatically and were not expected (causing the instantiation to fail) - I don't know why this only fails now and has not been failing previously
- Added dummy labels to `reader.to_data` calls